### PR TITLE
Add support for transferring aggregated accounts

### DIFF
--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/AggregatedAccountFilterer.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/AggregatedAccountFilterer.java
@@ -2,12 +2,16 @@ package org.folio.dew.batch.bursarfeesfines;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.folio.dew.batch.bursarfeesfines.service.BursarFilterAggregateEvaluator;
-import org.folio.dew.batch.bursarfeesfines.service.BursarFilterEvaluator;
-import org.folio.dew.domain.dto.BursarExportFilterAggregate;
+import org.folio.dew.domain.dto.Account;
 import org.folio.dew.domain.dto.BursarExportJob;
+import org.folio.dew.domain.dto.Item;
+import org.folio.dew.domain.dto.bursarfeesfines.AccountWithAncillaryData;
 import org.folio.dew.domain.dto.bursarfeesfines.AggregatedAccountsByUser;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.AfterStep;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +26,11 @@ public class AggregatedAccountFilterer
   @Value("#{jobExecutionContext['jobConfig']}")
   private BursarExportJob jobConfig;
 
+  @Value("#{jobExecutionContext['itemMap']}")
+  private Map<String, Item> itemMap;
+
+  private List<AccountWithAncillaryData> filteredAccounts = new ArrayList<>();
+
   @Override
   public AggregatedAccountsByUser process(
     AggregatedAccountsByUser aggregatedAccounts
@@ -32,9 +41,29 @@ public class AggregatedAccountFilterer
         jobConfig.getGroupByPatronFilter()
       )
     ) {
+      // Add all the accounts into aggregated accounts
+      for (Account account : aggregatedAccounts.getAccounts()) {
+        filteredAccounts.add(
+          AccountWithAncillaryData
+            .builder()
+            .account(account)
+            .user(aggregatedAccounts.getUser())
+            .item(itemMap.getOrDefault(account.getItemId(), null))
+            .build()
+        );
+      }
+
       return aggregatedAccounts;
     } else {
       return null;
     }
+  }
+
+  @AfterStep
+  public void afterStep(StepExecution stepExecution) {
+    stepExecution
+      .getJobExecution()
+      .getExecutionContext()
+      .put("filteredAccounts", filteredAccounts);
   }
 }

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/AggregatedAccountReader.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/AggregatedAccountReader.java
@@ -83,7 +83,6 @@ public class AggregatedAccountReader
       AccountWithAncillaryData accountWithAncillaryData = AccountWithAncillaryData
         .builder()
         .account(account)
-        .user(null)
         .user(userMap.get(account.getUserId()))
         .item(itemMap.getOrDefault(account.getItemId(), null))
         .build();
@@ -120,6 +119,11 @@ public class AggregatedAccountReader
     });
 
     log.info(aggregatedAccountsByUsersList.toString());
+
+    stepExecution
+      .getJobExecution()
+      .getExecutionContext()
+      .put("itemMap", itemMap);
 
     // initializing a totalAmount variable in jobExecutionContext
     stepExecution


### PR DESCRIPTION
I want to keep the transfer step the same so I just extracted the accounts in the Aggregated Accounts that passed the aggregate filter and make them into `AccountWithAncillaryData` and added them into `filteredAccounts` context.